### PR TITLE
Version 0.1.3

### DIFF
--- a/ppsim/__version__.py
+++ b/ppsim/__version__.py
@@ -1,1 +1,1 @@
-version = '0.1.2' # version line; WARNING: do not remove or change this line or comment
+version = '0.1.3' # version line; WARNING: do not remove or change this line or comment

--- a/ppsim/crn.py
+++ b/ppsim/crn.py
@@ -160,7 +160,7 @@ def reactions_to_dict(reactions: Iterable[Reaction], n: int, volume: float) \
     for reactants, outputs in transitions.items():
         if isinstance(outputs, dict):
             sum_probs = sum(prob for prob in outputs.values())
-            assert sum_probs <= 1.0, f'sum_probs exceeds 1: {sum_probs}'
+            assert sum_probs <= 1 + 2 ** -20, f'sum_probs exceeds 1: {sum_probs}'
 
     return transitions, max_rate
 

--- a/ppsim/simulation.py
+++ b/ppsim/simulation.py
@@ -322,7 +322,7 @@ class Simulation:
                 # when output is a distribution
                 if type(output) == dict:
                     s = sum(output.values())
-                    assert s <= 1, "The sum of output probabilities must be <= 1."
+                    assert s <= 1 + 2 ** -20, "The sum of output probabilities must be <= 1."
                     # ensure probabilities sum to 1
                     if 1 - s:
                         if (a, b) in output.keys():


### PR DESCRIPTION
Fixed a bug where sums of probabilities were required to be less than the float 1.0.
Rounding errors were leading to errors when this value was 1 + (machine epsilon). The inequalities are now <= 1 + 2 ** -20 to account for floating point errors.