### PR TITLE
Bugfix in Simulation.run

### DIFF
--- a/ppsim/__version__.py
+++ b/ppsim/__version__.py
@@ -1,1 +1,1 @@
-version = '0.1.5' # version line; WARNING: do not remove or change this line or comment
+version = '0.1.6' # version line; WARNING: do not remove or change this line or comment


### PR DESCRIPTION
If the simulator tried to run for an amount of time that was smaller than the next simulated interaction, it would still simulate at least one interaction. This could lead to Simulation.simulator.t and Simulation.time becoming out of sync if the history_interval was sufficiently small.

The time_to_steps function used in Simulation.run has now been changed to fix this.