### PR TITLE
Fixes #35; Declare build dependency on Cython using pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["setuptools", "wheel", "numpy<=1.20.1", "cython"]
+build-backend = "setuptools.build_meta"


### PR DESCRIPTION
## Description
Add pyproject.toml file to declare Cython as build dependency

## Related Issue
#35 

## Motivation and Context
Previously, running `pip install ppsim` without `cython` leads to import errors. Adding this file tells pip to install cython if the user does not have it, allowing the build to succeed.

## How Has This Been Tested?
Deployed the changes to Test PyPI: https://test.pypi.org/project/ppsimtest/0.1.6.6/

To test installation removed cpython and ppsim installations:

```
pip3.8 uninstall cython ppsim ppsimtest 
```

Then installed from Test PyPI

```
pip3.8 install -i https://test.pypi.org/simple/ --extra-index-url https://pypi.org/simple --no-cache-dir ppsimtest==0.1.6.6
```

> __Command Explanation__: The `-i https://test.pypi.org/simple/` tells pip to look in Test PyPI. The ` --extra-index-url https://pypi.org/simple` tells pip to look in regular PyPI for certain packages like setuptools. `--no-cache-dir` insures that pip is installing from the Test PyPI repository and not some local cached file. This long command is only needed for testing purposes. Once deployed to PyPI, the regular `pip install ppsim` command will run the installation.


Then, verified that

```py
import ppsim
```

runs without issue.

